### PR TITLE
refactor to replace `delete_comment` with `abandon_comment`

### DIFF
--- a/src/database/writes.py
+++ b/src/database/writes.py
@@ -37,11 +37,11 @@ def insert_channel_or_error(conn: sqlite3.Connection, channel_name: str, channel
         raise ValueError('Received invalid values for channel_id or channel_name')
 
 
-async def delete_comment(app, comment_id):
+async def abandon_comment(app, comment_id):
     return await coroutine(delete_comment_by_id)(app['writer'], comment_id)
 
 
-async def delete_comment_if_authorized(app, comment_id, **kwargs):
+async def abandon_comment_if_authorized(app, comment_id, **kwargs):
     authorized = await is_authentic_delete_signal(app, comment_id, **kwargs)
     if not authorized:
         return {'deleted': False}

--- a/src/database/writes.py
+++ b/src/database/writes.py
@@ -44,10 +44,10 @@ async def abandon_comment(app, comment_id):
 async def abandon_comment_if_authorized(app, comment_id, **kwargs):
     authorized = await is_authentic_delete_signal(app, comment_id, **kwargs)
     if not authorized:
-        return {'deleted': False}
+        return False
 
-    job = await app['comment_scheduler'].spawn(delete_comment(app, comment_id))
-    return {'deleted': await job.wait()}
+    job = await app['comment_scheduler'].spawn(abandon_comment(app, comment_id))
+    return await job.wait()
 
 
 async def write_comment(app, params):

--- a/src/server/handles.py
+++ b/src/server/handles.py
@@ -1,4 +1,3 @@
-# cython: language_level=3
 import logging
 import time
 
@@ -14,7 +13,7 @@ from src.database.queries import get_claim_hidden_comments
 from src.server.misc import is_valid_base_comment
 from src.server.misc import is_valid_credential_input
 from src.server.misc import make_error
-from src.database.writes import delete_comment_if_authorized
+from src.database.writes import abandon_comment_if_authorized
 from src.database.writes import write_comment
 from src.database.writes import hide_comments_where_authorized
 

--- a/src/server/handles.py
+++ b/src/server/handles.py
@@ -54,8 +54,8 @@ async def handle_create_comment(app, params):
         raise ValueError('base comment is invalid')
 
 
-async def handle_delete_comment(app, params):
-    return await delete_comment_if_authorized(app, **params)
+async def handle_abandon_comment(app, params):
+    return {'abandoned': await abandon_comment_if_authorized(app, **params)}
 
 
 async def handle_hide_comments(app, params):
@@ -70,8 +70,8 @@ METHODS = {
     'get_comments_by_id': handle_get_comments_by_id,
     'get_channel_from_comment_id': handle_get_channel_from_comment_id,
     'create_comment': handle_create_comment,
-    'delete_comment': handle_delete_comment,
-    'abandon_comment': handle_delete_comment,
+    'delete_comment': handle_abandon_comment,
+    'abandon_comment': handle_abandon_comment,
     'hide_comments': handle_hide_comments
 }
 
@@ -108,6 +108,10 @@ async def process_json(app, body: dict) -> dict:
 async def api_endpoint(request: web.Request):
     try:
         web.access_logger.info(f'Forwarded headers: {request.remote}')
+        logging.debug(f'Request: {request}')
+        for k, v in request.items():
+            logging.debug(f'{k}: {v}')
+
         body = await request.json()
         if type(body) is list or type(body) is dict:
             if type(body) is list:


### PR DESCRIPTION
This replaces all references to `delete_comment` from the **server** code. 
The database should continue to use `delete_comment` since that's what makes sense.

